### PR TITLE
Added and customized events that trigger github actions workflows

### DIFF
--- a/.github/workflows/Bionic CI.yml
+++ b/.github/workflows/Bionic CI.yml
@@ -1,5 +1,26 @@
 name: Bionic CI
-on: [push]
+on: 
+  push:
+    paths-ignore:
+      - 'datasets/**'
+      - 'docs/**'
+      - 'matlab/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'README.md'
+  pull_request:
+    paths-ignore:
+      - 'datasets/**'
+      - 'docs/**'
+      - 'matlab/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'README.md'
+  # enable manual trigger
+  workflow_dispatch:
+  schedule:
+    # run on first day of the month
+    - cron: '0 0 1 * *'
 jobs:
   Bionic-CI:
     runs-on: ubuntu-18.04

--- a/.github/workflows/Focal CI.yml
+++ b/.github/workflows/Focal CI.yml
@@ -1,5 +1,26 @@
 name: Focal CI
-on: [push]
+on: 
+  push:
+    paths-ignore:
+      - 'datasets/**'
+      - 'docs/**'
+      - 'matlab/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'README.md'
+  pull_request:
+    paths-ignore:
+      - 'datasets/**'
+      - 'docs/**'
+      - 'matlab/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'README.md'
+  # enable manual trigger
+  workflow_dispatch:
+  schedule:
+    # run on first day of the month
+    - cron: '0 0 1 * *'
 jobs:
   Focal-CI:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
 - applies to Bionic and Focal CI
 - push event now ignores when changes were only made to
   - anything in datasets, docs or matlab directory
   - .gitignore, LICENSE or README.md file
 - pull_request event added
   - same paths-ignore pattern as push event
 - added manually-triggered "workflow_dispatch" event
   - https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
 - added scheduled event on first day of the month